### PR TITLE
docs: add repository steward video walkthrough

### DIFF
--- a/examples/spring-ai-agents-md-coding-agent/README.md
+++ b/examples/spring-ai-agents-md-coding-agent/README.md
@@ -5,8 +5,8 @@ Shell 4.0.3, and the Spring AI AGENTS.md starter. It explores a repository, foll
 AGENTS.md instructions applicable to each file, and proposes reviewable changes. A model
 cannot apply its own proposal: a person must run `apply-change` explicitly.
 
-> **Video walkthrough:** Coming soon. Replace this sentence with a link to the YouTube
-> video after it is published.
+> **Video walkthrough:** [Build a Safe Coding Agent with Spring AI +
+> AGENTS.md](https://youtu.be/bIlYmp_iiBM)
 
 ## What the demo proves
 


### PR DESCRIPTION
## Summary

- replace the coding-agent README video placeholder with the published walkthrough
- link the Repository Steward demo at https://youtu.be/bIlYmp_iiBM

## Verification

- confirmed the README diff passes `git diff --check`
- confirmed commit `25e10e5` has a valid ED25519 signature

## Scope

Documentation-only change; no runtime behavior is affected.